### PR TITLE
Implement parallel uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "svelte-file-share",
       "version": "0.0.1",
       "dependencies": {
-        "axios": "^1.7.4"
+        "axios": "^1.7.4",
+        "p-limit": "^6.1.0"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^3.0.0",
@@ -2195,6 +2196,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/p-limit": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.1.0.tgz",
+      "integrity": "sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
@@ -3837,6 +3853,18 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/youch": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "type": "module",
   "dependencies": {
-    "axios": "^1.7.4"
+    "axios": "^1.7.4",
+    "p-limit": "^6.1.0"
   }
 }

--- a/src/routes/guest/[key]/+page.svelte
+++ b/src/routes/guest/[key]/+page.svelte
@@ -2,15 +2,20 @@
 
 <script>
     // Imports
+    import pLimit from 'p-limit';
 	import axios from 'axios';
+    
 
     let files;                          // selected files to upload
     let expiryDate;                     // Store selected expiration date
     export let data;                    // data from backend
+    let chunkCount = 0;                 // Total chunk count
     const debug = true;                 // Enable debug logging in console
     let uploadProgress;                 // user facing upload progress percentage
+    let chunked = false;                // Flag indicating if chunked upload is active
     let currentFile = "";               // current file being uploaded
     let uploading = false;              // upload state
+    let finishedChunks = 0;             // finished uploaded chunks
     let textCopied = false;             // Show or hide the "Copied!" message
     let uploadFinished = false;         // Set when all files finished upload
 
@@ -37,7 +42,7 @@
         uploading = true;
 
         // Static vars
-        const chunkSize = 100663296;    // 96MB (in bytes)
+        const chunkSize = 67108864;     // 64MB (in bytes)
         const token = data.token;       // Auth token (from cookies)
         
         // A unified "response" variable, for API requests
@@ -69,6 +74,7 @@
             // Use multipart upload if file size > chunk size
             if (file.size > chunkSize) {
                 if (debug) console.log(`File size (${file.size}) larger than chunk size (${chunkSize}), using chunked upload`);
+                chunked = true;
 
                 // Set upload action to create multipart upload
                 headers["X-Upload-Action"] = "create";
@@ -84,7 +90,7 @@
 
                 // End early if response is not Created
                 if (response.status !== 201) {
-                    console.error(`Failed to create multipart upload: ${response.data}`);
+                    alert(`Failed to create multipart upload: ${response.data}`);
                     return;
                 }
 
@@ -98,47 +104,63 @@
 
                 let part = 1;           // Current part number
                 let offset = 0;         // Current offset from file start
-                let partsList = [];     // Keep track of list of parts to complete upload 
+                let partList = [];     // Keep track of list of parts to complete upload 
+                let chunkList = [];     // List of chunks
 
-                // Main chunked upload loop
-                // Until the offset moves beyond the end of the file...
+                // Use p-limit to run 8 chunk uploads
+                const limiter = pLimit(8);
+
+                // Set up chunk list
                 while (offset < file.size) {
-                    if (debug) console.log(`Uploading chunk ${part}, range ${offset} -> ${offset + chunkSize}`);
-                    
-                    // Set current chunk header
-                    headers["X-Upload-Part"] = part;
-
-                    // Upload chunk request
-                    response = await axios.put(
-                        '/api/guest/upload',
-                        file.slice(offset, offset + chunkSize),
-                        {
-                            headers: headers,
-                            onUploadProgress: (progressEvent) => {
-                                const { loaded } = progressEvent;
-                                uploadProgress = Math.floor(((offset + loaded) * 100) / file.size);
-                                if (debug) console.log(`Upload progress: ${(offset + loaded)} out of ${file.size}`);
-                            }
-                        }
-                    );
-
-                    if (response.status !== 200) {
-                        console.error(`Uploading file part error: ${response.data}`);
-                        return;
-                    }
-
-                    partsList.push(response.data);  // Add R2UploadedPart object to array to complete upload later
-                    offset = offset + chunkSize;    // Set new offset after upload completed
+                    // Add chunk to list
+                    chunkList.push({ part: part, total: file.size, chunk: file.slice(offset, offset + chunkSize) });
+                    offset = offset + chunkSize;    // Set new offset
                     part++;                         // Increment part number
+                }
+
+                // Set total chunk count
+                chunkCount = chunkList.length;
+
+                // Set up list of promises
+                const promiseList = chunkList.map((chunk) => {
+                    return limiter(() => {
+                        if (debug) console.log(`Uploading part ${chunk.part}`);
+                        return axios.put(
+                            '/api/guest/upload',
+                            chunk.chunk,
+                            {
+                                headers: {
+                                    ...headers,
+                                    'X-Upload-Part': chunk.part
+                                }
+                            }
+                        ).then((res) => {
+                                finishedChunks++
+                                partList.push(res.data)
+                                if (debug) console.log(`Finished uploading chunk ${chunk.part}`);
+                            }
+                        );
+                    })
+                })
+
+                // Wait for all uploads to complete
+                const result = await Promise.allSettled(promiseList);
+                
+                // Fail if part count is incorrect
+                if(finishedChunks !== chunkCount) {
+                    alert("Upload failed.");
+                    return;
                 }
 
                 // Set upload action to complete multipart upload
                 headers["X-Upload-Action"] = "complete";
 
+                if (debug) console.log(partList);
+
                 // Complete multipart upload
                 response = await axios.post(
                     '/api/guest/upload',
-                    partsList,
+                    partList,
                     {
                         headers: headers
                     }
@@ -146,15 +168,20 @@
 
                 // Error out if response is not OK
                 if (response.status !== 200) {
-                    console.error(`Failed to complete multipart upload: ${response.data}`);
+                    alert(`Failed to complete multipart upload: ${response.data}`);
                     return;
                 }
+
+                // Reset chunk count vars
+                chunkCount = 0;
+                finishedChunks = 0;
             }
 
             // File size < chunk size, send in one request
             else {
                 if (debug) console.log(`File size (${file.size}) smaller than chunk size (${chunkSize}), using single request upload`);
-
+                chunked = false;
+                
                 // Set upload action to single request upload
                 headers["X-Upload-Action"] = "direct";
                 
@@ -248,7 +275,11 @@
         <p>Uploading file: {currentFile}</p>
         <div class="overflow-hidden p-1 rounded-lg bg-slate-700">
             <div class="flex relative justify-center items-center h-6">
-                <div class="relative text-sm font-medium text-white">{uploadProgress}%</div>
+                {#if !chunked}
+                    <div class="relative text-sm font-medium text-white">{uploadProgress}%</div>
+                {:else}
+                    <div class="relative text-sm px-4 font-medium text-white">Uploaded {finishedChunks} out of {chunkCount} chunks</div>
+                {/if}
             </div>
         </div>
     {:else} <!-- Show share links when upload completed-->

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -34,7 +34,7 @@
         uploading = true;
 
         // Static vars
-        const chunkSize = 67108864;    // 64MB (in bytes)
+        const chunkSize = 67108864;     // 64MB (in bytes)
         const token = data.token;       // Auth token (from cookies)
         
         // A unified "response" variable, for API requests

--- a/src/routes/upload/+page.svelte
+++ b/src/routes/upload/+page.svelte
@@ -3,7 +3,8 @@
 <script>
     // Imports
     import Header from '../../components/Header.svelte';
-	import axios from 'axios';
+	import pLimit from 'p-limit';
+    import axios from 'axios';
 
     let files;                          // selected files to upload
     let expiryDate;                     // Store selected expiration date
@@ -30,7 +31,7 @@
         uploading = true;
 
         // Static vars
-        const chunkSize = 100663296;    // 96MB (in bytes)
+        const chunkSize = 67108864;    // 64MB (in bytes)
         const token = data.token;       // Auth token (from cookies)
         
         // A unified "response" variable, for API requests
@@ -95,6 +96,9 @@
                 let part = 1;           // Current part number
                 let offset = 0;         // Current offset from file start
                 let partsList = [];     // Keep track of list of parts to complete upload 
+                let promiseList = [];   // List of ongoing upload promises
+
+                const limiter = pLimit(16);
 
                 // Main chunked upload loop
                 // Until the offset moves beyond the end of the file...


### PR DESCRIPTION
Upload up to eight 64MB chunks of a file bigger than 64MB at once, improving upload bandwidth substantially for large files.